### PR TITLE
Highlight escape sequences and format string placeholders

### DIFF
--- a/themes/snazzy-operator-plus-color-theme.json
+++ b/themes/snazzy-operator-plus-color-theme.json
@@ -114,6 +114,16 @@
       }
     },
     {
+      "name": "Escape Characters",
+      "scope": [
+        "constant.character.escape",
+        "constant.other"
+      ],
+      "settings": {
+        "foreground": "#ffd3d9"
+      }
+    },
+    {
       "name": "Class",
       "scope": "entity.name.type.class",
       "settings": {


### PR DESCRIPTION
Added some TextMate scopes for highlighting the characters, will help in clarity for C strings.